### PR TITLE
referencing issue #3 - unsafe yaml loading

### DIFF
--- a/funconf.py
+++ b/funconf.py
@@ -624,7 +624,7 @@ class Config(MutableMapping):
         :param stream: the configuration to be loaded using ``yaml.load``.
         :type stream: stream object
         """
-        config = yaml.load(stream)
+        config = yaml.safe_load(stream)
         if not isinstance(config, dict):
             return
         for section, options in config.items():


### PR DESCRIPTION
Using yaml safe_load instead of load.

We are more likely to raise a yaml.constructor.ConstructorError, should
we catch this and raise a more readable error if it is expected unsafe
behaviour?
