### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,6 @@ Project support:
    :target: https://coveralls.io/r/mjdorma/funconf?branch=master
    :alt: Latest PyPI version
 
-.. |pypi_version| image:: https://pypip.in/v/funconf/badge.png
+.. |pypi_version| image:: https://img.shields.io/pypi/v/funconf.svg
    :target: https://crate.io/packages/funconf/
    :alt: Latest PyPI version


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20funconf))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `funconf`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.